### PR TITLE
feat: cli prompt and corresponding option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Environment
+/.venv
+/venv
+/.env
+/env
+
 # Build & Binary
 /target
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,9 @@ struct Cli {
   input: Option<PathBuf>,
   #[arg(short, long, help = "output file path")]
   output: Option<PathBuf>,
+
+  #[arg(short, long, help = "enable verbose prompt")]
+  verbose: bool,
 }
 
 #[derive(clap::Subcommand)]
@@ -42,6 +45,9 @@ fn main() {
         file.read_to_string(&mut buffer)
             .expect("Failed to read from input file");
       } else {
+        if cli.verbose {
+          println!("Please enter the text to encode (Ctrl+D to finish):");
+        }
         std::io::stdin()
             .read_to_string(&mut buffer)
             .expect("Failed to read from stdin");
@@ -62,9 +68,15 @@ fn main() {
         file.write_all(encoded.as_bytes())
             .expect("Failed to write to output file");
       } else {
+        if cli.verbose {
+          println!("Encoded:");
+        }
         std::io::stdout()
             .write_all(encoded.as_bytes())
             .expect("Failed to write to stdout");
+        if cli.verbose {
+          println!();
+        }
       }
     }
     Commands::Decode => {
@@ -73,6 +85,9 @@ fn main() {
         file.read_to_string(&mut buffer)
             .expect("Failed to read from input file");
       } else {
+        if cli.verbose {
+          println!("Please enter the text to decode (Ctrl+D to finish):");
+        }
         std::io::stdin()
             .read_to_string(&mut buffer)
             .expect("Failed to read from stdin");
@@ -97,9 +112,15 @@ fn main() {
         file.write_all(decoded.as_bytes())
             .expect("Failed to write to output file");
       } else {
+        if cli.verbose {
+          println!("Decoded:");
+        }
         std::io::stdout()
             .write_all(decoded.as_bytes())
             .expect("Failed to write to stdout");
+        if cli.verbose {
+          println!();
+        }
       }
     }
     Commands::Example => {


### PR DESCRIPTION
添加了一个`-v` / `--verbose` 选项
打开以后encode decode的时候会有个基本的输入输出prompt
并且输出时会添加一个换行
这种情况下就是直接在interactive shell里使用 而不是作为管道的一部分